### PR TITLE
Clean up configs

### DIFF
--- a/keepalived_config.yaml
+++ b/keepalived_config.yaml
@@ -12,7 +12,6 @@ data:
     }
 
     vrrp_script chk_api {
-      # TODO: Set to api VIP
       script "/bin/sh -c '/usr/sbin/ip a show br-ex | /usr/bin/grep -q @API_VIP_V4/32'"
       interval 2
       weight 20
@@ -21,7 +20,6 @@ data:
     }
 
     vrrp_script chk_ingress {
-        # TODO: Set to ingress VIP
         script "/bin/sh -c '/usr/sbin/ip a show br-ex | /usr/bin/grep -q @ING_VIP_V4/32'"
         interval 2
         weight 20
@@ -29,22 +27,18 @@ data:
         fall 1
     }
 
-    # TODO: Update with cluster name
-    vrrp_instance ostest_API {
+    vrrp_instance @CLUSTER_NAME_API {
         state BACKUP
         interface br-ex
-        # TODO: Make sure this doesn't conflict
         virtual_router_id @VIRTUAL_ROUTER_ID_API
         priority 40
         advert_int 1
 
         authentication {
             auth_type PASS
-            # TODO: Update with cluster name
             auth_pass @AUTH_PASS_API
         }
         virtual_ipaddress {
-            # TODO: Set to API VIP
             @API_VIP_V6/128
         }
         track_script {
@@ -52,22 +46,18 @@ data:
         }
     }
 
-    # TODO: Update with cluster name
-    vrrp_instance ostest_INGRESS {
+    vrrp_instance @CLUSTER_NAME_INGRESS {
         state BACKUP
         interface br-ex
-        # TODO: Make sure this doesn't conflict
         virtual_router_id @VIRTUAL_ROUTER_ID_ING
         priority 20
         advert_int 1
 
         authentication {
             auth_type PASS
-            # TODO: Update with cluster name
             auth_pass @AUTH_PASS_ING
         }
         virtual_ipaddress {
-            # TODO: Set to ingress VIP
             @ING_VIP_V6/128
         }
         track_script {
@@ -82,7 +72,6 @@ data:
     }
 
     vrrp_script chk_ingress {
-        # TODO: Set to ingress VIP
         script "/bin/sh -c '/usr/sbin/ip a show br-ex | /usr/bin/grep -q @ING_VIP_V4/32'"
         interval 2
         weight 20
@@ -90,22 +79,18 @@ data:
         fall 1
     }
 
-    # TODO: Update with cluster name
-    vrrp_instance ostest_INGRESS {
+    vrrp_instance @CLUSTER_NAME_INGRESS {
         state BACKUP
         interface br-ex
-        # TODO: Make sure this doesn't conflict
         virtual_router_id @VIRTUAL_ROUTER_ID_ING
         priority 20
         advert_int 1
 
         authentication {
             auth_type PASS
-            # TODO: Update with cluster name
             auth_pass @AUTH_PASS_ING
         }
         virtual_ipaddress {
-            # TODO: Set to ingress VIP
             @ING_VIP_V6/128
         }
         track_script {

--- a/keepalived_daemonset.yaml
+++ b/keepalived_daemonset.yaml
@@ -94,6 +94,11 @@ spec:
               configMapKeyRef:
                 name: user-params
                 key: auth_pass_ing
+          - name: CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: user-params
+                key: cluster_name
 
         command:
         - /bin/bash
@@ -112,7 +117,6 @@ spec:
           set -ex
           # Ensure that we don't have stale VIPs configured
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1931505
-          # TODO: Replace with VIPs
           remove_vip "$API_VIP_V6"
           remove_vip "$ING_VIP_V6"
           
@@ -123,7 +127,8 @@ spec:
              | sed -e "s/@API_VIP_V6/$API_VIP_V6/" \
              | sed -e "s/@ING_VIP_V6/$ING_VIP_V6/" \
              | sed -e "s/@AUTH_PASS_API/$AUTH_PASS_API/" \
-             | sed -e "s/@AUTH_PASS_ING/$AUTH_PASS_ING/" > /etc/keepalived/keepalived-v6.conf
+             | sed -e "s/@AUTH_PASS_ING/$AUTH_PASS_ING/" \
+             | sed -e "s/@CLUSTER_NAME/$CLUSTER_NAME/" > /etc/keepalived/keepalived-v6.conf
 
           # Create iptables rule to loadbalance traffic coming in on VIP
           if ! ip6tables -L PREROUTING -t nat | grep OCP_API_LB_REDIRECT; then
@@ -258,6 +263,11 @@ spec:
               configMapKeyRef:
                 name: user-params
                 key: auth_pass_ing
+          - name: CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: user-params
+                key: cluster_name
 
         command:
         - /bin/bash
@@ -276,7 +286,6 @@ spec:
           set -ex
           # Ensure that we don't have stale VIPs configured
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1931505
-          # TODO: Replace with VIPs
           remove_vip "$API_VIP_V6"
           remove_vip "$ING_VIP_V6"
           
@@ -287,7 +296,8 @@ spec:
              | sed -e "s/@API_VIP_V6/$API_VIP_V6/" \
              | sed -e "s/@ING_VIP_V6/$ING_VIP_V6/" \
              | sed -e "s/@AUTH_PASS_API/$AUTH_PASS_API/" \
-             | sed -e "s/@AUTH_PASS_ING/$AUTH_PASS_ING/" > /etc/keepalived/keepalived-v6.conf
+             | sed -e "s/@AUTH_PASS_ING/$AUTH_PASS_ING/" \
+             | sed -e "s/@CLUSTER_NAME/$CLUSTER_NAME/" > /etc/keepalived/keepalived-v6.conf
 
           if [ -s "/etc/keepalived/keepalived-v6.conf" ]; then
               /usr/sbin/keepalived -f /etc/keepalived/keepalived-v6.conf --dont-fork --vrrp --log-detail --log-console 

--- a/user_config.yaml
+++ b/user_config.yaml
@@ -12,4 +12,6 @@ data:
   ing_vip_v6: "fd2e:6f44:5dd8:c956::4"
   auth_pass_api: "ostest_api_vip"
   auth_pass_ing: "ostest_ingress_vip"
+  # FIXME: Unused?
   keepalived_image_name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24dbf54c5e8b6a714598b4f81b0cdcfe5b9c2be99f30dfc79a495d62b64f81cf"
+  cluster_name: "ostest"


### PR DESCRIPTION
Removes obsolete TODO comments and allows the cluster name to be set
via the config map rather than hard-coded in the config template.

One FIXME to find a way to use the image specified in the config map
too, which currently appears to be unused. I'm not sure if there's
a way to retrieve the image value from the config map, but it seems
like there must be.