### PR TITLE
Add script to automate deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+keepalived_daemonset.yaml

--- a/README.md
+++ b/README.md
@@ -1,11 +1,4 @@
 # Deployment instructions
 
-Run the following commands:
-
-- oc apply -f namespace.yaml
 - Edit user_config.yaml file
-- oc apply -f user_config.yaml
-- oc apply -f scc.yaml
-- oc adm policy add-scc-to-user privileged -n keepalived-v6  -z cluster-hosted-keepalived
-- oc apply -f keepalived_config.yaml
-- oc apply -f keepalived_daemonset.yaml
+- Run deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+# The image can't be looked up from the config map, so we have to manually
+# insert it into the daemonset spec.
+image="$(yq -r .data.keepalived_image_name user_config.yaml)"
+sed -e "s|@KEEPALIVED_IMAGE|$image|" keepalived_daemonset.tmpl > keepalived_daemonset.yaml
+
+oc apply -f ./namespace.yaml
+oc apply -f ./user_config.yaml
+oc apply -f ./scc.yaml
+oc adm policy add-scc-to-user privileged -n keepalived-v6 -z cluster-hosted-keepalived
+oc apply -f keepalived_config.yaml
+oc apply -f keepalived_daemonset.yaml

--- a/keepalived_daemonset.tmpl
+++ b/keepalived_daemonset.tmpl
@@ -49,8 +49,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
-        # TODO: Get the image from the default keepalived pod manifest
-        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24dbf54c5e8b6a714598b4f81b0cdcfe5b9c2be99f30dfc79a495d62b64f81cf
+        image: @KEEPALIVED_IMAGE
         env:
           - name: NSS_SDB_USE_CACHE
             value: "no"
@@ -218,8 +217,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
-        # TODO: Get the image from the default keepalived pod manifest
-        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24dbf54c5e8b6a714598b4f81b0cdcfe5b9c2be99f30dfc79a495d62b64f81cf
+        image: @KEEPALIVED_IMAGE
         env:
           - name: NSS_SDB_USE_CACHE
             value: "no"

--- a/user_config.yaml
+++ b/user_config.yaml
@@ -12,6 +12,5 @@ data:
   ing_vip_v6: "fd2e:6f44:5dd8:c956::4"
   auth_pass_api: "ostest_api_vip"
   auth_pass_ing: "ostest_ingress_vip"
-  # FIXME: Unused?
-  keepalived_image_name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:24dbf54c5e8b6a714598b4f81b0cdcfe5b9c2be99f30dfc79a495d62b64f81cf"
+  keepalived_image_name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3e96c1755163ecb2827bf4b4d1dfdabf2a125e6aeef620a0b8ba52d0c450432c"
   cluster_name: "ostest"


### PR DESCRIPTION
The script serves two purposes: First, it automates all of the
commands that were previously documented in the readme. Second, it
automates updating of the image in the pod definitions. It's not
possible to look up the image location from the config map directly,
but we can look at the config map YAML from the script and extract
the image location that way. This makes user_config.yaml the only
place users will need to modify values.